### PR TITLE
Update transformations.py

### DIFF
--- a/src/arvo/transformations.py
+++ b/src/arvo/transformations.py
@@ -150,11 +150,11 @@ def _transpose_pitch_in_scale_space(
     if steps == 0:
         return
     if steps > 0:
-        direction = "ascending"
+        direction = 1
     else:
-        direction = "descending"
+        direction = -1
         steps *= -1
-    new_pitch = reference_scale.next(original_pitch, direction, steps)
+    new_pitch = reference_scale.nextPitch(original_pitch, direction, steps)
     original_pitch.step = new_pitch.step
     original_pitch.octave = new_pitch.octave
     original_pitch.accidental = new_pitch.accidental


### PR DESCRIPTION
* argument direction no longer takes str, but int or bool (or, most correctly, globals ASCENDING and DESCENDING)
* function next() is deprecated

passing str for direction was giving error 
```
/usr/local/lib/python3.10/dist-packages/music21/scale/intervalNetwork.py in getNext(self, nodeStart, direction)
   1141                                      'postEdge', postEdge])
   1142             # return None
-> 1143             raise IntervalNetworkException('could not find any edges')
   1144 
   1145         # if we have multiple edges, we may need to select based on weight

IntervalNetworkException: could not find any edges
```

see https://web.mit.edu/music21/doc/moduleReference/moduleScale.html#music21.scale.ConcreteScale.nextPitch